### PR TITLE
Introduce opt-in serialization through Serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,12 @@ travis-ci = { repository = "sdleffler/qp-trie-rs", branch = "master" }
 
 [dependencies]
 debug_unreachable = "0.1.1"
+serde = { version = "1.0.11", optional = true, features = ["derive"] }
 unreachable = "1.0.0"
 
 [dev-dependencies]
+bincode = "0.8.0"
 qptrie = "0.2.2"
 quickcheck = "0.4.1"
 rand = "0.3.15"
+serde_json = "1.0.3"

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,78 @@
+use trie::Trie;
+
+use std::borrow::Borrow;
+use std::fmt;
+use std::marker::PhantomData;
+
+use serde::de::{Deserialize, Deserializer, Visitor, MapAccess};
+use serde::ser::{Serialize, Serializer, SerializeMap};
+
+
+impl<K, V> Serialize for Trie<K, V>
+where
+    K: Serialize + Borrow<[u8]>,
+    V: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {   
+        let mut map = serializer.serialize_map(Some(self.count()))?;
+        for (k, v) in self.iter() {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+
+struct TrieVisitor<K, V> {
+    marker: PhantomData<fn() -> Trie<K, V>>,
+}
+
+
+impl<K, V> TrieVisitor<K, V> {
+    fn new() -> Self {
+        TrieVisitor {
+            marker: PhantomData,
+        }
+    }
+}
+
+
+impl<'de, K, V> Visitor<'de> for TrieVisitor<K, V>
+where
+    K: Deserialize<'de> + Borrow<[u8]>,
+    V: Deserialize<'de>,
+{
+    type Value = Trie<K, V>;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a qp-trie")
+    }
+
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where M: MapAccess<'de>
+    {
+        let mut trie = Trie::new();
+        while let Some((key, value)) = access.next_entry()? {
+            trie.insert(key, value);
+        }
+
+        Ok(trie)
+    }
+}
+
+
+impl<'de, K, V> Deserialize<'de> for Trie<K, V>
+where
+    K: Deserialize<'de> + Borrow<[u8]>,
+    V: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(TrieVisitor::new())
+    }
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -8,6 +8,7 @@ use trie::Break;
 
 /// A wrapper for `String` which implements `Borrow<[u8]>` and hashes in the same way as a byte
 /// slice.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BString(String);
 


### PR DESCRIPTION
Now that Rust has enshrined Serde 1.0 as the canonical serialization infrastructure, it's quite important for data structure crates to use it, as Serde support can seldom be implemented downstream.

This PR enables opt-in derivation of the Serialize and Deserialize traits through the `serde` feature flag. (The feature is named according to the [interoperability guidelines](https://rust-lang-nursery.github.io/api-guidelines/interoperability.html#data-structures-implement-serdes-serialize-deserialize-c-serde) from the language nursery.) The patch itself is nothing more than a few `derive` declarations hidden behind `cfg` attributes and sprinkled on relevant structs.

Although derived impls should be sound, it may still be desirable to test them; doing so would require tossing in a concrete serializer in the form of an optional dev dependency. I would be happy to amend the patch with such a test if the additional dependency is fine by you.


(On a unrelated note – and I apologize for interfering with repository housekeeping – there appears to be trailing whitespace in a few files. You may want to remove it, as trailing whitespace behaves poorly across different git and editor configurations, and often muddles diffs.)