### PR TITLE
Benchmark against FNV hashmaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ unreachable = "1.0.0"
 
 [dev-dependencies]
 bincode = "0.8.0"
+fnv = "1.0.5"
 qptrie = "0.2.2"
 quickcheck = "0.4.1"
 rand = "0.3.15"

--- a/README.md
+++ b/README.md
@@ -109,35 +109,28 @@ benchmarks based on those shown in the `qptrie` repository.
 
 ## Benchmarks
 
-Benchmarks are run against the `qptrie` crate and the Rust stdlib `BTreeMap`
-and `HashMap`. `qp_trie::Trie` consistently outperforms the `std::collections`
-`BTreeMap` and `HashMap` and also the `qptrie` crate's implementation on my
-machine - a Chromebook Pixel 2.0 running GalliumOS.
-
-Benchmarks can be reproduced using `cargo bench`. The Rust version used was
-`rustc 1.19.0-nightly (cfb5debbc 2017-06-12)`. Run several times, the
-benchmarks are consistent in their outputs but I selected the lowest variance
-results to display here.
+Benchmarks are run against the `qptrie` crate, the Rust stdlib `BTreeMap`, and
+the stdlib `HashMap` with both default and FNV hashing. `qp_trie::Trie`
+consistently outperforms the `std::collections` `BTreeMap` and `HashMap`, as
+well as the `qptrie` crate's implementation.
 
 Benchmarks named `exotrie` are using the `qptrie::Trie` implementation.
 
 ```
-running 8 tests
-test bench_btreemap_get    ... bench: 114,172,574 ns/iter (+/- 10,890,962)
-test bench_btreemap_insert ... bench: 118,547,331 ns/iter (+/- 13,464,035)
-test bench_exotrie_get     ... bench:  54,297,605 ns/iter (+/- 4,392,593)
-test bench_exotrie_insert  ... bench:  62,537,678 ns/iter (+/- 21,724,153)
-test bench_hashmap_get     ... bench:  63,191,541 ns/iter (+/- 6,685,288)
-test bench_hashmap_insert  ... bench:  55,076,618 ns/iter (+/- 2,212,986)
-test bench_trie_get        ... bench:  48,232,553 ns/iter (+/- 6,583,801)
-test bench_trie_insert     ... bench:  57,935,037 ns/iter (+/- 16,538,104)
-
-test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out
+test bench_btreemap_get      ... bench: 111,468,098 ns/iter (+/- 10,103,247)
+test bench_btreemap_insert   ... bench: 112,124,846 ns/iter (+/- 14,296,195)
+test bench_exotrie_get       ... bench:  46,195,582 ns/iter (+/- 16,943,561)
+test bench_exotrie_insert    ... bench:  52,886,847 ns/iter (+/- 15,574,538)
+test bench_fnvhashmap_get    ... bench:   9,530,109 ns/iter (+/- 820,763)
+test bench_fnvhashmap_insert ... bench:  21,281,107 ns/iter (+/- 7,254,084)
+test bench_hashmap_get       ... bench:  49,653,426 ns/iter (+/- 7,004,051)
+test bench_hashmap_insert    ... bench:  47,771,824 ns/iter (+/- 4,979,606)
+test bench_trie_get          ... bench:  40,898,914 ns/iter (+/- 13,400,062)
+test bench_trie_insert       ... bench:  50,966,392 ns/iter (+/- 18,077,240)
 ```
 
 ## Future work
 
-- Benchmark against `FxHasher`/`FnvHasher` to get a better idea of how `Trie` compares against `HashMap`.
 - Add wrapper types for `String` and `str` to make working with strings easier.
 
 ## License

--- a/benches/qpcmp.rs
+++ b/benches/qpcmp.rs
@@ -1,9 +1,11 @@
 #![feature(test)]
 
+extern crate fnv;
 extern crate qptrie;
 extern crate qp_trie;
 extern crate test;
 
+use fnv::FnvHashMap;
 use std::collections::{BTreeMap, HashMap};
 
 use qptrie::Trie as ExoTrie;
@@ -138,6 +140,42 @@ fn bench_hashmap_insert(b: &mut Bencher) {
 #[bench]
 fn bench_hashmap_get(b: &mut Bencher) {
     let mut trie = HashMap::new();
+
+    let a = 1_234u32;
+    let mut x = 0u32;
+
+    for _ in 0..499_980 {
+        x = (x + a) % 499_979;
+        let key = [x as u8, (x >> 8) as u8, (x >> 16) as u8, (x >> 24) as u8];
+        trie.insert(key, ());
+    }
+
+    b.iter(move || for _ in 0..499_979 {
+        x = (x + a) % 499_979;
+        let key = [x as u8, (x >> 8) as u8, (x >> 16) as u8, (x >> 24) as u8];
+        trie.get(&key).unwrap();
+    });
+}
+
+
+#[bench]
+fn bench_fnvhashmap_insert(b: &mut Bencher) {
+    let mut trie = FnvHashMap::default();
+
+    let a = 1_234u32;
+    let mut x = 0u32;
+
+    b.iter(move || for _ in 0..499_980 {
+        x = (x + a) % 499_979;
+        let key = [x as u8, (x >> 8) as u8, (x >> 16) as u8, (x >> 24) as u8];
+        trie.insert(key, ());
+    });
+}
+
+
+#[bench]
+fn bench_fnvhashmap_get(b: &mut Bencher) {
+    let mut trie = FnvHashMap::default();
 
     let a = 1_234u32;
     let mut x = 0u32;


### PR DESCRIPTION
Between Fx and FNV, only FNV provides a useful comparison: on my machine, Fx performs only marginally better than SipHash, and FNV handily bests either. Arguably this is an artifact of working with very short keys only (and possibly of the fixed key distribution), and should be addressed at some later time.

The updated results are included in the readme, although strictly speaking "Chromebook Pixel 2.0 running GalliumOS" becomes a white lie. I can amend the patch with your own results if you are feeling zealous enough.