### PR TITLE
Implement basic `std::collections` methods

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -111,3 +111,114 @@ impl<'a, K: 'a, V: 'a> Iterator for IterMut<'a, K, V> {
         }
     }
 }
+
+
+/// An iterator over immutable references to the keys in the QP-trie.
+#[derive(Clone, Debug)]
+pub struct Keys<'a, K: 'a, V: 'a> {
+    stack: Vec<&'a Node<K, V>>,
+}
+
+
+impl<'a, K, V> Keys<'a, K, V> {
+    pub fn new(node: &'a Node<K, V>) -> Keys<'a, K, V> {
+        Keys { stack: vec![node] }
+    }
+}
+
+
+impl<'a, K, V> Default for Keys<'a, K, V> {
+    fn default() -> Self {
+        Keys { stack: vec![] }
+    }
+}
+
+
+impl<'a, K: 'a, V: 'a> Iterator for Keys<'a, K, V> {
+    type Item = &'a K;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stack.pop() {
+            Some(&Node::Leaf(ref leaf)) => Some(leaf.key.borrow()),
+            Some(&Node::Branch(ref branch)) => {
+                self.stack.extend(branch.iter().rev());
+                self.next()
+            }
+            None => None,
+        }
+    }
+}
+
+
+/// An iterator over immutable references to the values in the QP-trie.
+#[derive(Clone, Debug)]
+pub struct Values<'a, K: 'a, V: 'a> {
+    stack: Vec<&'a Node<K, V>>,
+}
+
+
+impl<'a, K, V> Values<'a, K, V> {
+    pub fn new(node: &'a Node<K, V>) -> Values<'a, K, V> {
+        Values { stack: vec![node] }
+    }
+}
+
+
+impl<'a, K, V> Default for Values<'a, K, V> {
+    fn default() -> Self {
+        Values { stack: vec![] }
+    }
+}
+
+
+impl<'a, K: 'a, V: 'a> Iterator for Values<'a, K, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stack.pop() {
+            Some(&Node::Leaf(ref leaf)) => Some(&leaf.val),
+            Some(&Node::Branch(ref branch)) => {
+                self.stack.extend(branch.iter().rev());
+                self.next()
+            }
+            None => None,
+        }
+    }
+}
+
+
+/// An iterator over mutable references to the values in the QP-trie.
+#[derive(Debug)]
+pub struct ValuesMut<'a, K: 'a, V: 'a> {
+    stack: Vec<&'a mut Node<K, V>>,
+}
+
+
+impl<'a, K, V> ValuesMut<'a, K, V> {
+    pub fn new(node: &'a mut Node<K, V>) -> ValuesMut<'a, K, V> {
+        ValuesMut { stack: vec![node] }
+    }
+}
+
+
+impl<'a, K, V> Default for ValuesMut<'a, K, V> {
+    fn default() -> Self {
+        ValuesMut { stack: vec![] }
+    }
+}
+
+
+impl<'a, K: 'a, V: 'a> Iterator for ValuesMut<'a, K, V> {
+    type Item = &'a mut V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stack.pop() {
+            Some(&mut Node::Leaf(ref mut leaf)) => Some(&mut leaf.val),
+            Some(&mut Node::Branch(ref mut branch)) => {
+                self.stack.extend(branch.iter_mut().rev());
+                self.next()
+            }
+            None => None,
+        }
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -176,6 +176,28 @@ quickcheck! {
         TestResult::from_bool(lcp == trie.longest_common_prefix(prefix.as_slice()))
     }
 
+    fn iter_keys(kvs : HashMap<Vec<u8>, usize>) -> bool {
+        let mut given_keys: Vec<_> = kvs.keys().cloned().collect();
+        let trie: Trie<_, _> = kvs.into_iter().collect();
+        let mut yielded_keys: Vec<_> = trie.keys().cloned().collect();
+
+        given_keys.sort();
+        yielded_keys.sort();
+
+        given_keys == yielded_keys
+    }
+
+    fn iter_values(kvs : HashMap<Vec<u8>, usize>) -> bool {
+        let mut given_values: Vec<_> = kvs.values().cloned().collect();
+        let trie: Trie<_, _> = kvs.into_iter().collect();
+        let mut yielded_values: Vec<_> = trie.values().cloned().collect();
+
+        given_values.sort();
+        yielded_values.sort();
+
+        given_values == yielded_values
+    }
+
     #[cfg(feature = "serde")]
     fn serialize(kvs: Vec<(Vec<u8>, usize)>) -> bool {
         let original: Trie<Vec<u8>, usize> = kvs.into_iter().collect();


### PR DESCRIPTION
This takes care of the trivial methods listed in #11:

- `clear`
- `is_empty`
- `contains_key`
- `Keys` iterator
- `Values`, `ValuesMut` iterators

Later on, we may want to refactor the `iter` module a bit to minimize repetition.