### PR TITLE
Upgrade all dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rust:
   - stable
   - beta
   - nightly
+script: cargo test --features serde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ license = "MPL-2.0"
 travis-ci = { repository = "sdleffler/qp-trie-rs", branch = "master" }
 
 [dependencies]
-debug_unreachable = "0.1.1"
+new_debug_unreachable = "1.0.1"
 serde = { version = "1.0.11", optional = true, features = ["derive"] }
 unreachable = "1.0.0"
 
 [dev-dependencies]
-bincode = "0.8.0"
+bincode = "1.0"
 fnv = "1.0.5"
 qptrie = "0.2.2"
-quickcheck = "0.4.1"
-rand = "0.3.15"
+quickcheck = "0.7"
+rand = "0.5"
 serde_json = "1.0.3"

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -201,7 +201,7 @@ quickcheck! {
     #[cfg(feature = "serde")]
     fn serialize(kvs: Vec<(Vec<u8>, usize)>) -> bool {
         let original: Trie<Vec<u8>, usize> = kvs.into_iter().collect();
-        let serialized = bincode::serialize(&original, bincode::Infinite).unwrap();
+        let serialized = bincode::serialize(&original).unwrap();
         let deserialized: Trie<_, _> = bincode::deserialize(&serialized).unwrap();
 
         deserialized == original
@@ -215,7 +215,7 @@ quickcheck! {
             trie.remove(&k);
         }
 
-        let serialized = bincode::serialize(&trie, bincode::Infinite).unwrap();
+        let serialized = bincode::serialize(&trie).unwrap();
         let deserialized: Trie<Vec<u8>, usize> = bincode::deserialize(&serialized).unwrap();
 
         deserialized == Trie::new()
@@ -442,7 +442,7 @@ fn serialize_max_branching_factor(){
     });
 
     let original: Trie<Vec<u8>, u8> = kvs.collect();
-    let serialized = bincode::serialize(&original, bincode::Infinite).unwrap();
+    let serialized = bincode::serialize(&original).unwrap();
     let deserialized: Trie<_, _> = bincode::deserialize(&serialized).unwrap();
 
     assert_eq!(deserialized, original);


### PR DESCRIPTION
Replaced the now unmaintained `debug_unreachable` crate with servo's `new_debug_unreachable` fork.