### PR TITLE
Add a rustfmt configuration file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+# This file intentionally left almost blank
+#
+# The empty `rustfmt.toml` makes rustfmt use the default configuration,
+# overriding any which may be found in the contributor's home or parent
+# folders.

--- a/src/node.rs
+++ b/src/node.rs
@@ -634,14 +634,12 @@ impl<K: Borrow<[u8]>, V> Node<K, V> {
             Some(Node::Branch(..))
                 // unsafe: root has been matched as some branch.
                 if unsafe { root.as_ref().unchecked_unwrap().unwrap_branch_ref() }
-                       
                        .get_exemplar(prefix)
                        .key_slice()
                        .starts_with(prefix) => {
 
                 // unsafe: same rationale.
                 if unsafe { root.as_ref().unchecked_unwrap().unwrap_branch_ref() }
-                    
                     .choice >= prefix.len() * 2
                 {
                     root.take()


### PR DESCRIPTION
Including a `.rustfmt.toml` file in the repository makes for smoother contributions by folk who have their own rustfmt configuration.

(I am not sure where the two empty lines came from. If you're using VS Code, the fault might lie in some odd interaction between rustfmt and a newly introduced editor setting to only format the modified portions of a file.)