### PR TITLE
Don't use `mem::replace` where assignment will do

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -443,7 +443,7 @@ impl<K: Borrow<[u8]>, V> Node<K, V> {
             }
             Node::Branch(branch) => {
                 if branch.choice <= graft {
-                    mem::replace(self, Node::Branch(branch));
+                    *self = Node::Branch(branch);
                     if let Node::Branch(ref mut branch) = *self {
                         let index = branch.index(key.borrow());
 
@@ -552,7 +552,7 @@ impl<K: Borrow<[u8]>, V> Node<K, V> {
 
                         branch_mut.clear_last()
                     };
-                    mem::replace(self, node);
+                    *self = node;
                 }
 
                 Some(leaf)
@@ -613,7 +613,7 @@ impl<K: Borrow<[u8]>, V> Node<K, V> {
                 if unsafe { self.unwrap_branch_mut() }.is_singleton() {
                     // unsafe: same rationale.
                     let node = unsafe { self.unwrap_branch_mut() }.clear_last();
-                    mem::replace(self, node);
+                    *self = node;
                 }
 
                 Some(prefix_node)


### PR DESCRIPTION
A trivial change to satisfy the default linter.