### PR TITLE
Add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 keywords = ["trie", "radix", "map", "key", "value"]
 
-categories = ["data-structures", "text-processing", "rust-patterns"]
+categories = ["data-structures", "text-processing", "rust-patterns", "no-std"]
 
 license = "MPL-2.0"
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,6 +1,6 @@
-use std::borrow::Borrow;
-use std::marker::PhantomData;
-use std::mem;
+use core::borrow::Borrow;
+use core::marker::PhantomData;
+use core::mem;
 
 use unreachable::UncheckedOptionExt;
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,5 @@
-use std::borrow::Borrow;
+use alloc::{vec, vec::Vec};
+use core::borrow::Borrow;
 
 use node::Node;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 #[macro_use]
 extern crate debug_unreachable;
 extern crate unreachable;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,6 @@
-use std::borrow::Borrow;
-use std::fmt;
-use std::mem;
+use core::borrow::Borrow;
+use core::fmt;
+use core::mem;
 
 use unreachable::UncheckedOptionExt;
 
@@ -188,18 +188,18 @@ impl<K, V> Branch<K, V> {
     }
 
     #[inline]
-    pub fn iter(&self) -> ::std::slice::Iter<Node<K, V>> {
+    pub fn iter(&self) -> ::core::slice::Iter<Node<K, V>> {
         self.entries.iter()
     }
 
     #[inline]
-    pub fn iter_mut(&mut self) -> ::std::slice::IterMut<Node<K, V>> {
+    pub fn iter_mut(&mut self) -> ::core::slice::IterMut<Node<K, V>> {
         self.entries.iter_mut()
     }
 }
 
 impl<K, V> IntoIterator for Branch<K, V> {
-    type IntoIter = ::std::vec::IntoIter<Node<K, V>>;
+    type IntoIter = ::alloc::vec::IntoIter<Node<K, V>>;
     type Item = Node<K, V>;
 
     #[inline]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,8 +1,8 @@
 use trie::Trie;
 
-use std::borrow::Borrow;
-use std::fmt;
-use std::marker::PhantomData;
+use core::borrow::Borrow;
+use core::fmt;
+use core::marker::PhantomData;
 
 use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, Serializer};

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -1,6 +1,6 @@
-use std::fmt;
-use std::slice::{Iter, IterMut};
-use std::vec::IntoIter;
+use alloc::vec::{IntoIter, Vec};
+use core::fmt;
+use core::slice::{Iter, IterMut};
 
 use unreachable::UncheckedOptionExt;
 

--- a/src/subtrie.rs
+++ b/src/subtrie.rs
@@ -1,6 +1,6 @@
-use std::borrow::Borrow;
-use std::fmt;
-use std::ops::Index;
+use core::borrow::Borrow;
+use core::fmt;
+use core::ops::Index;
 
 use iter::Iter;
 use node::Node;

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1,7 +1,8 @@
-use std::borrow::Borrow;
-use std::fmt;
-use std::iter::FromIterator;
-use std::ops::{Index, IndexMut};
+use alloc::borrow::ToOwned;
+use core::borrow::Borrow;
+use core::fmt;
+use core::iter::FromIterator;
+use core::ops::{Index, IndexMut};
 
 use entry::{make_entry, Entry};
 use iter::{IntoIter, Iter, IterMut, Keys, Values, ValuesMut};

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::cmp;
+use core::cmp;
 
 // Get the "nybble index" corresponding to the `n`th nybble in the given slice.
 //
@@ -84,6 +84,8 @@ pub fn nybble_get_mismatch(left: &[u8], right: &[u8]) -> Option<(u8, usize)> {
 
 #[cfg(test)]
 mod test {
+    use alloc::vec::Vec;
+
     use quickcheck::TestResult;
 
     use super::*;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,7 +1,9 @@
-use std::borrow::Borrow;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use core::borrow::Borrow;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
 
 use trie::Break;
 


### PR DESCRIPTION
Radix tries could be super useful in embedded contexts, so I decided to look into what it might take to support `no_std` build environments in this crate. As it turns out, it almost supports `no_std` + `alloc` already - it just needed the imports to be tweaked accordingly to point to `core` and `alloc` rather than `std`.